### PR TITLE
Add `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @egwilborn @juliechan01 @sirbully @sophiedang0101


### PR DESCRIPTION
This will automatically add all members as reviewers whenever a PR is created. We will be notified when we need to review a PR.